### PR TITLE
feat: API 사용량 제한 및 입력 글자수 검증 구현

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 OPENAI_API_KEY=your_api_key_here
 MODEL_NAME=gpt-4o-mini
 DB_PATH=/data/chatbot.db
+
+MAX_TOKENS=500
+MAX_USER_INPUT=1000

--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,5 @@ yarn-error.log*
 *.rar
 
 
-
 # API Keys and Secrets
 .env

--- a/apps/api/chat_api.py
+++ b/apps/api/chat_api.py
@@ -166,12 +166,16 @@ def get_conversation_messages_for_ai(conversation_id: int):
 
 def generate_ai_reply_from_env(conversation_id: int, latest_user_message: str) -> str:
     api_key = os.getenv("OPENAI_API_KEY", "").strip()
+    MAX_TOKENS = int(os.getenv("MAX_TOKENS", "500"))
+    MAX_USER_INPUT = int(os.getenv("MAX_USER_INPUT", "1000"))
     if not api_key:
         raise HTTPException(status_code=500, detail="서버에 OPENAI_API_KEY가 설정되지 않았습니다.")
 
     model_name = os.getenv("MODEL_NAME", "gpt-4o-mini").strip() or "gpt-4o-mini"
     history = get_conversation_messages_for_ai(conversation_id)
     latest_user_message = (latest_user_message or "").strip()
+    if len(latest_user_message) > MAX_USER_INPUT:
+        raise HTTPException(status_code=400, detail=f"입력이 너무 깁니다! 최대 {MAX_USER_INPUT}자까지 가능합니다.")
 
     if latest_user_message:
         if not history or history[-1].get("role") != "user" or history[-1].get("content") != latest_user_message:
@@ -183,6 +187,7 @@ def generate_ai_reply_from_env(conversation_id: int, latest_user_message: str) -
     client = OpenAI(api_key=api_key)
     response = client.chat.completions.create(
         model=model_name,
+        max_tokens=MAX_TOKENS,
         messages=[
             {
                 "role": "system",


### PR DESCRIPTION
- 무분별한 API 호출로 인한 비용 발생을 방지하고, 챗봇의 응답 안정성을 높이기 위해 안전장치를 추가했습니다.

 주요 수정 사항
1. `.env` 파일에 `MAX_TOKENS`와 `MAX_USER_INPUT`을 설정하여 코드에서 동적으로 관리할 수 있게 했습니다.
2. 사용자가 1,000자(기본값)를 초과하여 입력할 경우, AI에게 요청을 보내기 전에 시스템 메시지로 안내하고 차단하도록 로직을 구현했습니다.
3. `ChatOpenAI` 설정에 `max_tokens`를 추가하여 AI 답변이 너무 길어져 비용이 과다하게 발생하는 것을 방지했습니다.